### PR TITLE
Switching render location from just the path to the full URL

### DIFF
--- a/lib/redux-router-engine.js
+++ b/lib/redux-router-engine.js
@@ -31,7 +31,7 @@ class ReduxRouterEngine {
   }
 
   render(req, options) {
-    const location = req.path || (req.url && req.url.path);
+    const location = req.url.path || req.url;
 
     return this._matchRoute({routes: this.options.routes, location})
       .then((match) => {

--- a/test/spec/redux-router-engine.spec.js
+++ b/test/spec/redux-router-engine.spec.js
@@ -186,7 +186,7 @@ describe("redux-router-engine", function () {
       log: () => {
       },
       app: {},
-      url: {}
+      url: {path: "/test"}
     };
 
     const engine = new ReduxRouterEngine({routes, createReduxStore});


### PR DESCRIPTION
The original location was missing the query section of the URL. This was causing the injected react prop "location.search" to be undefined during server side rendering. 